### PR TITLE
Fixed SampleContentKeyPolicyOperations

### DIFF
--- a/SampleContentKeyPolicyOperations.md
+++ b/SampleContentKeyPolicyOperations.md
@@ -33,7 +33,7 @@ var newpol = client.ContentKeyPolicies.Create(
     {
         new ContentKeyPolicyOption(
             "option1",
-            new ContentKeyPolicyConfigurationWidevine("{}"),
+            new ContentKeyPolicyWidevineConfiguration("{}"),
             new ContentKeyPolicyTokenRestriction(
                 "issuer",
                 "audience",


### PR DESCRIPTION
There is a typo on SampleContentKeyPolicyOperations.md

The class `ContentKeyPolicyConfigurationWidevine` should be `ContentKeyPolicyWidevineConfiguration`.